### PR TITLE
Fix synthetic monitoring Playwright version mismatch

### DIFF
--- a/.github/workflows/synthetic.yml
+++ b/.github/workflows/synthetic.yml
@@ -20,7 +20,8 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
+        working-directory: synthetic
+        run: yarn playwright install --with-deps chromium
 
       - name: Run synthetic simulation
         working-directory: synthetic


### PR DESCRIPTION
## Summary
- The synthetic workflow used `npx playwright install` which resolved the **latest** Playwright from npm, while the simulation runs with the **lockfile** version via `yarn`. When Playwright 1.59.0 was published, the installed browser binaries no longer matched what 1.58.2 expected, causing `browserType.launch` to fail.
- Changed to `yarn playwright install` so the browser install uses the same Playwright version as the simulation runtime.

## Test plan
- [x] Verify the next scheduled synthetic monitoring run passes